### PR TITLE
Add bottom mobile navigation bar for smaller screens such as tablets and mobile phones

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import { getProfileData } from './routes/profile/[profile]'
 import Avatar from './components/Avatar'
 import { SessionProvider, useSession } from './states/session'
 
+import MobileNav from './components/layout/MobileNav'
+
 const Navigation = () => {
 	const session = useSession()
 	const profile = createAsync(() => getProfileData(session.did))
@@ -121,6 +123,7 @@ const App = (props: RouteSectionProps) => {
 								</Suspense>
 							</ErrorBoundary>
 						</div>
+						<MobileNav />
 					</main>
 					<aside class={`${styles.sidebar} ${styles.right}`}>
 						<ErrorBoundary fallback={<p>An error occurred</p>}>

--- a/src/components/auth/Protected.tsx
+++ b/src/components/auth/Protected.tsx
@@ -1,0 +1,5 @@
+import { type JSXElement } from 'solid-js'
+
+const Protected = (props: { children: JSXElement }) => <>{props.children}</>
+
+export default Protected

--- a/src/components/layout/MobileNav.module.css
+++ b/src/components/layout/MobileNav.module.css
@@ -1,0 +1,31 @@
+.nav {
+	flex: 1;
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	position: sticky;
+	bottom: 0;
+	min-height: 3.75rem;
+	max-height: 3.75rem;
+	height: 100%;
+	z-index: 1;
+	background-color: var(--background-primary);
+	gap: 1rem;
+	align-items: center;
+	justify-content: space-around;
+	border-top: 1px solid var(--border);
+}
+
+.nav .icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 3.75rem;
+	height: 3.75rem;
+	min-height: 3.75rem;
+	line-height: 0;
+}
+
+.nav .icon a {
+	color: var(--text-secondary);
+}

--- a/src/components/layout/MobileNav.module.css
+++ b/src/components/layout/MobileNav.module.css
@@ -29,3 +29,9 @@
 .nav .icon a {
 	color: var(--text-secondary);
 }
+
+@media only screen and (min-width: 540px) {
+	.nav {
+		display: none;
+	}
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,73 @@
+import { For, Show } from 'solid-js'
+import { A, createAsync } from '@solidjs/router'
+import Avatar from '../Avatar'
+import { useSession } from '../../states/session'
+import { getProfileData } from '../../routes/profile/[profile]'
+import { HomeIcon } from '../../assets/HomeIcon'
+import { SearchIcon } from '../../assets/SearchIcon'
+import { BellIcon } from '../../assets/BellIcon'
+import { BubbleIcon } from '../../assets/BubbleIcon'
+import styles from './MobileNav.module.css'
+
+const MobileNavigation = () => {
+	// To-do: reconcile this component with main Navigation
+	const session = useSession()
+	const profile = createAsync(() => getProfileData(session.did))
+
+	const links = [
+		{
+			label: 'Home',
+			href: '/',
+			icon: <HomeIcon />
+		},
+		{
+			label: 'Search',
+			href: '/search',
+			icon: <SearchIcon />
+		},
+		{
+			label: 'Chat',
+			href: '/chat',
+			icon: <BubbleIcon />,
+			authenticated: true
+		},
+		{
+			label: 'Notifications',
+			href: '/notifications',
+			icon: <BellIcon />,
+			authenticated: true
+		}
+	]
+
+	return (
+		<nav class={styles.nav}>
+			<For each={links}>
+				{(link) => (
+					<Show when={!link.authenticated || profile()}>
+						<div class={styles.icon}>
+							<A
+								end
+								activeClass='highlight'
+								aria-label={link.label}
+								href={link.href}
+							>
+								{link.icon}
+							</A>
+						</div>
+					</Show>
+				)}
+			</For>
+			<Show when={profile()}>
+				{(profile) => (
+					<div class={styles.icon}>
+						<A href={`/profile/${profile().handle}`}>
+							<Avatar src={profile().avatar} size='1.5rem' />
+						</A>
+					</div>
+				)}
+			</Show>
+		</nav>
+	)
+}
+
+export default MobileNavigation


### PR DESCRIPTION
Closes #68 

Order of links are different for desktop and mobile. In mobile, tags and lists are hidden. Moreover, a better discovery method should be implemented for mobile.