### PR TITLE
Fix for search bar behavior

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,6 +9,7 @@ import {
 	useAction,
 	useParams,
 	useNavigate,
+	useLocation,
 	useBeforeLeave
 } from '@solidjs/router'
 import searchActorsTypeahead from '../api/actor/searchActorsTypeahead'
@@ -16,7 +17,6 @@ import styles from './Search.module.css'
 import { ListItem } from './Section'
 import listStyles from './Section.module.css'
 import Spinner from './Spinner'
-import useMatches from '../utils/useMatches'
 
 const typeaheadSearch = cache(
 	async (query: string) => await searchActorsTypeahead(query),
@@ -30,10 +30,15 @@ const goToSearch = action(async (query: string) => {
 // This same search input component is used in the /search page as well as
 // in the sidebar for other pages
 const Search = () => {
+	const location = useLocation()
 	const [results, setSearchResults] =
 		createSignal<Awaited<ReturnType<typeof searchActorsTypeahead>>>()
 	const navigate = useNavigate()
-	const isSearchOrHashtagPage = useMatches(() => ['/search', '/hashtag'])
+	// const isSearchOrHashtagPage = () => false //useMatches(() => ['/search', '/hashtag'])
+	const isSearchOrHashtagPage = () =>
+		['/search', '/hashtag'].some((path) =>
+			location.pathname.startsWith(path)
+		)
 	const isSearchPage = useMatch(() => '/search')
 	const isHashtagPage = useMatch(() => '/hashtag/:hashtag')
 	const params = useParams()
@@ -62,7 +67,7 @@ const Search = () => {
 			// .trim() has UX issues when a user tries to search for a sentence
 			// search input automatically strips space even if there is user intent to have spaces
 			// possible solution is to just .trim() in the API call and not override UI
-			setSearchParams({ q: value }) // tried to remove .trim()
+			setSearchParams({ q: value.trim() }) // tried to remove .trim()
 		} else {
 			// Do we need to use this query signal?
 			// Can't we just pass this to typeaheadSearch() and set the results

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,7 +7,7 @@ import {
 	useParams,
 	useMatch
 } from '@solidjs/router'
-import useMatches from '../../utils/useMatches'
+// import useMatches from '../../utils/useMatches'
 // import getSuggestions from '../../api/actor/getSuggestions'
 import getPopularFeedGenerators from '../../api/unspecced/getPopularFeedGenerators'
 import Search from '../Search'
@@ -43,7 +43,11 @@ const Sidebar = () => {
 	// this should be dynamic with :profile, wrap this with auth
 	// const users = createAsync(getSuggestions)
 	const feeds = createAsync(getPopularFeedGenerators)
-	const isSearch = useMatches(() => ['/search', '/hashtag'])
+	// const isSearch = useMatches(() => ['/search', '/hashtag'])
+	const isSearch = () =>
+		['/search', '/hashtag'].some((path) =>
+			location.pathname.startsWith(path)
+		)
 	const isTrends = useMatch(() => '/trends')
 	return (
 		<Suspense>

--- a/src/utils/useMatches.ts
+++ b/src/utils/useMatches.ts
@@ -3,6 +3,8 @@ import { useLocation } from '@solidjs/router'
 // @solidjs/router useMatch() doesn't yet allow matching for multiple routes yet
 
 // Returns () => true if one of routes given match the current path
+
+// This function causes unnecessary invalidations
 const useMatches = (routes: () => string[]) => {
 	const location = useLocation()
 	return () => routes().some((path) => location.pathname.startsWith(path))


### PR DESCRIPTION
Typed search query is not being properly synced with search params. #74 

Issue was caused by buggy implementation of useMatches used inside <Search /> component that causes unnecessary invalidations. Each key stroke changes the URL - and this URL is tracked - therefore each change in location was wrongly interpreted as a need to reload the page.